### PR TITLE
Removing VISTA from Ballot Areas and adding ACCOUNT_NUM to Parcels

### DIFF
--- a/metadata/Cadastre/parcels_schema.md
+++ b/metadata/Cadastre/parcels_schema.md
@@ -60,3 +60,7 @@ Date the parcel was received by UGRC.
 ### CoParcel_U
 
 <!--- No definition for this field. -->
+
+### ACCOUNT_NUM
+
+<!--- No definition for this field. -->

--- a/metadata/political/vista_ballot_areas.md
+++ b/metadata/political/vista_ballot_areas.md
@@ -1,6 +1,6 @@
 # Title
 
-Utah VISTA Ballot Areas
+Utah Ballot Areas
 
 ## ID
 
@@ -8,11 +8,11 @@ fb485021-1a93-43b3-bd3b-13c68d7e5b3c
 
 ## Brief Summary
 
-Official voting precincts used by Utah's VISTA election framework.
+Official voting precincts used by Utah's election framework.
 
 ## Summary
 
-Statewide polygon layer that depicts voting precinct and subprecinct boundaries. This dataset serves as the baseline for the Voter Information and State Tracking Application (VISTA), as well as many other voter information websites.
+Statewide polygon layer that depicts voting precinct and subprecinct boundaries. This dataset serves as the baseline for the statewide voter registration database, as well as many other voter information websites.
 
 ## Description
 
@@ -22,7 +22,7 @@ Voting precincts are used to determine a voter's ballot composition and polling 
 
 ### What is the purpose of the dataset?
 
-This dataset is actively used in all 29 counties in Utah. The counties have adopted a GIS-based approach to manage precinct-to-residence assignment within VISTA, the statewide voter registration database. This dataset also drives many of the State's voter information pages and helps citizens know [how and where to vote](https://votesearch.utah.gov/voter-search/search/search-by-address/how-and-where-can-i-vote).
+This dataset is actively used in all 29 counties in Utah. The counties have adopted a GIS-based approach to manage precinct-to-residence assignment within the statewide voter registration database. This dataset also drives many of the State's voter information pages and helps citizens know [how and where to vote](https://votesearch.utah.gov/voter-search/search/search-by-address/how-and-where-can-i-vote).
 
 ### What does the dataset represent?
 


### PR DESCRIPTION
This is a pull request for two minor edits to layers already merged into MAIN. I removed mentions of VISTA from the Ballot Areas layer in Political (it is now titled 'Utah Ballot Areas', unless we want to change that). I also added the field "ACCOUNT_NUM" to the schema doc for Basic Parcels per Rick's request. 