### PR TITLE
PLSS Edit Tracker

### DIFF
--- a/metadata/Cadastre/plss_edit_tracker.md
+++ b/metadata/Cadastre/plss_edit_tracker.md
@@ -1,0 +1,51 @@
+# Title
+
+PLSS Edit Tracker
+
+## ID
+
+50e0ced2-3c4f-4bf6-b504-67d64e73e25a
+
+## Brief Summary
+
+## Summary
+
+## Description
+
+Editing Tracking feacture class created from PLSS Sections. Will be edited to show partners which areas are being edited, which are an upcoming project area, and open areas.
+
+For Partners using the PLSS Fabric, to share information about edits to the PLSS Fabric that the different agencies will be editing on.
+
+Different fabrics are being use due to security restictions set at agency sites.
+
+### What is the dataset?
+
+### What is the purpose of the dataset?
+
+### What does the dataset represent?
+
+### How was the dataset created?
+
+### How reliable and accurate is the dataset?
+
+## Credits
+
+### Data Source
+
+### Host
+
+## Restrictions
+
+## License
+
+## Tags
+
+## Secondary Category
+
+## Data Page Link
+
+## Update
+
+### Update Schedule
+
+### Previous Updates

--- a/metadata/Cadastre/plss_edit_tracker.md
+++ b/metadata/Cadastre/plss_edit_tracker.md
@@ -8,37 +8,58 @@ PLSS Edit Tracker
 
 ## Brief Summary
 
+Polygon dataset of PLSS sections that displays edits and edit dates.
+
 ## Summary
+
+Other PLSS datasets can be found in the [Cadastre Data Index](https://gis.utah.gov/products/sgid/cadastre/).
 
 ## Description
 
-Editing Tracking feacture class created from PLSS Sections. Will be edited to show partners which areas are being edited, which are an upcoming project area, and open areas.
-
-For Partners using the PLSS Fabric, to share information about edits to the PLSS Fabric that the different agencies will be editing on.
-
-Different fabrics are being use due to security restictions set at agency sites.
-
 ### What is the dataset?
+
+Originally established in 1785 and currently administered by the Bureau of Land Management (BLM), the Public Land Survey System (PLSS) is a nationwide framework for surveying, dividing, and quantifying land. PLSS sections are divided into a grid with 640 acres in each square, which is further divided into [quarter sections](https://gis.utah.gov/products/sgid/cadastre/plss-quarter-sections/) (160 acres per square) and [quarter quarter sections](https://gis.utah.gov/products/sgid/cadastre/plss-quarter-quarter-sections/) (40 acres per square).
+
+This dataset contains PLSS sections with additional attributes to show when the PLSS fabric was last edited.
 
 ### What is the purpose of the dataset?
 
+This dataset was created to show recent and historic edits to the PLSS fabric.
+
 ### What does the dataset represent?
+
+Each polygon in this dataset represents a PLSS section. Features in this dataset contain the BLM PLSS ID number, section number, township and range (label), number of edits over the lifetime of the section (edits) and the date the section was last edited (edit_date).
 
 ### How was the dataset created?
 
+This data is derived from the [Utah PLSS Fabric](https://gis.utah.gov/products/sgid/cadastre/parcel-fabric/).
+
+<!--- Is there a particular app or script that updated the edits field when changes are made? --->
+
 ### How reliable and accurate is the dataset?
+
+This dataset reflects current section boundaries and displays the number of edits made by all PLSS partners in Utah. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
 
 ## Credits
 
 ### Data Source
 
+BLM
+
 ### Host
+
+UGRC
 
 ## Restrictions
 
 ## License
 
 ## Tags
+
+- Public Land Survey System
+- PLSS Sections
+- BLM
+- Bureau of Land Management
 
 ## Secondary Category
 
@@ -47,5 +68,7 @@ Different fabrics are being use due to security restictions set at agency sites.
 ## Update
 
 ### Update Schedule
+
+<!--- Do we have an update schedule for this? --->
 
 ### Previous Updates


### PR DESCRIPTION
The original metadata for [this layer](https://opendata.gis.utah.gov/datasets/utah::utah-plss-edit-tracker/about) said this:

> Editing Tracking feacture class created from PLSS Sections. Will be edited to show partners which areas are being edited, which are an upcoming project area, and open areas. For Partners using the PLSS Fabric, to share information about edits to the PLSS Fabric that the different agencies will be editing on. Different fabrics are being use due to security restictions set at agency sites.

However, this layer doesn't seem to show which areas are being edited or which are an upcoming project area. The layer has fields for EDITS, which seems to be the total number of edits (no time period specified) and the EDIT_DATE, which I assume is the last modified date. It's also possible that the EDITS field is how many edits were made on that date? Basically, I think we need some clarification on what those two fields mean. In any case, I'm not sure this layer shows what the original metadata describes--is this a case of outdated metadata, or am I misunderstanding the functionality of the layer?

Additionally, the last sentence about different fabrics being used--how does that apply to this dataset? 

Thank you for your help!