### PR TITLE
Unpopulated Areas 2010 Approx

### DIFF
--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -8,37 +8,52 @@ Utah Unpopulated Areas 2010 Approx
 
 ## Brief Summary
 
-Represent the boundary of the State of Utah for mapping purposes at a scale of 1:24000 or coarser.
-
-This dataset depicts the Utah State Boundary as digitized from USGS 7.5 minute quad map series. The boundary should be coincident with the outer boundary of the SGID024.CountyBoundaries dataset.
-
-This dataset originally had the wrong metadata.
+Polygon dataset of unpopulated areas in Utah dissolved as a single feature.
 
 ## Summary
+
+This dataset contains a polygon representing unpopulated areas in Utah as of the 2010 Census. For 2020 Census data products, please see the [Demographic Data Index](https://gis.utah.gov/products/sgid/demographic/) available from the SGID.
 
 ## Description
 
 ### What is the dataset?
 
+Census blocks are small geographic zones through which population data can be collected and organized. These blocks are often bounded by features such as roads, rivers, or property lines. This dataset includes Census blocks in unpopulated areas of Utah as of the 2010 Census that have been dissolved into a single polygon.
+
 ### What is the purpose of the dataset?
+
+Geography is a fundamental aspect of the Census, providing the framework for the once-a-decade count of population and housing. You can read more about some of the key geography changes in the Kem C. Gardner Policy Institute's 2020 Census Geography [Blog](https://gardner.utah.edu/blog/blog-whats-new-in-utahs-census-2020-geography/) and [fact sheet](https://d36oiwf74r1rap.cloudfront.net/wp-content/uploads/Geog-FS-Mar2021.pdf).
 
 ### What does the dataset represent?
 
+This dataset displays areas that contain little or no residential districts or developed areas as a single polygon feature. This dataset does not contain demographic data.
+
 ### How was the dataset created?
 
+UGRC created this dataset using the original 2010 Census Blocks from the US Census Bureau. We used aerial imagery to determine unpopulated areas of Utah. This dataset was updated in 2015 using new aerial photography and address point locations.
+
 ### How reliable and accurate is the dataset?
+
+Unpopulated areas shown in this dataset are approximate only. This layer is for historical reference and does not reflect current population numbers or Census block boundaries. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
 
 ## Credits
 
 ### Data Source
 
+US Census Bureau
+
 ### Host
+
+UGRC
 
 ## Restrictions
 
 ## License
 
 ## Tags
+
+- US Census Bureau
+- Census Blocks
 
 ## Secondary Category
 
@@ -47,5 +62,7 @@ This dataset originally had the wrong metadata.
 ## Update
 
 ### Update Schedule
+
+Static
 
 ### Previous Updates

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -30,7 +30,7 @@ This dataset displays areas that contain little or no residential districts or d
 
 ### How was the dataset created?
 
-UGRC created this dataset using the original 2010 Census Blocks from the US Census Bureau. We used aerial imagery to determine unpopulated areas of Utah. This dataset was updated in 2015 using new aerial photography and address point locations.
+UGRC created this dataset using parts of the original 2010 Census data from the US Census Bureau. Populated census blocks and a buffer around known addresses were used erase populated areas within the state, thus leaving behind the unpopulated areas in this dataset.
 
 ### How reliable and accurate is the dataset?
 

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -18,7 +18,7 @@ This dataset contains a polygon representing unpopulated areas in Utah, derived 
 
 ### What is the dataset?
 
-Census blocks are small geographic zones through which population data can be collected and organized. These blocks are often bounded by features such as roads, rivers, or property lines. This dataset includes Census blocks in unpopulated areas of Utah as of the 2010 Census that have been dissolved into a single polygon.
+This dataset is a representation of Utah areas that have little to no population, buildings, or addresses, dissolved into a single polygon.
 
 ### What is the purpose of the dataset?
 

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -22,7 +22,7 @@ Census blocks are small geographic zones through which population data can be co
 
 ### What is the purpose of the dataset?
 
-Geography is a fundamental aspect of the Census, providing the framework for the once-a-decade count of population and housing. You can read more about some of the key geography changes in the Kem C. Gardner Policy Institute's 2020 Census Geography [Blog](https://gardner.utah.edu/blog/blog-whats-new-in-utahs-census-2020-geography/) and [fact sheet](https://d36oiwf74r1rap.cloudfront.net/wp-content/uploads/Geog-FS-Mar2021.pdf).
+This dataset was created to represent the portion of Utah with little to no permanent population.  Geography is a fundamental aspect of the Census, providing the framework for the once-a-decade count of population and housing. You can read more about some of the key geography changes in the Kem C. Gardner Policy Institute's 2020 Census Geography [Blog](https://gardner.utah.edu/blog/blog-whats-new-in-utahs-census-2020-geography/) and [fact sheet](https://d36oiwf74r1rap.cloudfront.net/wp-content/uploads/Geog-FS-Mar2021.pdf).
 
 ### What does the dataset represent?
 

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -34,7 +34,7 @@ UGRC created this dataset using the original 2010 Census Blocks from the US Cens
 
 ### How reliable and accurate is the dataset?
 
-Unpopulated areas shown in this dataset are approximate only. This layer is for historical reference and does not reflect current population numbers or Census block boundaries. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
+Unpopulated areas shown in this dataset are approximate only. This layer is for historical reference and does not reflect current population numbers or Census data. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
 
 ## Credits
 

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -1,0 +1,51 @@
+# Title
+
+Utah Unpopulated Areas 2010 Approx
+
+## ID
+
+87112b87-1e64-49e7-a291-e35e188ca250
+
+## Brief Summary
+
+Represent the boundary of the State of Utah for mapping purposes at a scale of 1:24000 or coarser.
+
+This dataset depicts the Utah State Boundary as digitized from USGS 7.5 minute quad map series. The boundary should be coincident with the outer boundary of the SGID024.CountyBoundaries dataset.
+
+This dataset originally had the wrong metadata.
+
+## Summary
+
+## Description
+
+### What is the dataset?
+
+### What is the purpose of the dataset?
+
+### What does the dataset represent?
+
+### How was the dataset created?
+
+### How reliable and accurate is the dataset?
+
+## Credits
+
+### Data Source
+
+### Host
+
+## Restrictions
+
+## License
+
+## Tags
+
+## Secondary Category
+
+## Data Page Link
+
+## Update
+
+### Update Schedule
+
+### Previous Updates

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -12,7 +12,7 @@ Polygon dataset of unpopulated areas in Utah dissolved as a single feature.
 
 ## Summary
 
-This dataset contains a polygon representing unpopulated areas in Utah as of the 2010 Census. For 2020 Census data products, please see the [Demographic Data Index](https://gis.utah.gov/products/sgid/demographic/) available from the SGID.
+This dataset contains a polygon representing unpopulated areas in Utah, derived from 2010 Census and addressing data. For 2020 Census data products, please see the [Demographic Data Index](https://gis.utah.gov/products/sgid/demographic/) available from the SGID.
 
 ## Description
 

--- a/metadata/demographic/unpopulated_areas_2010_approx.md
+++ b/metadata/demographic/unpopulated_areas_2010_approx.md
@@ -12,7 +12,7 @@ Polygon dataset of unpopulated areas in Utah dissolved as a single feature.
 
 ## Summary
 
-This dataset contains a polygon representing unpopulated areas in Utah, derived from 2010 Census and addressing data. For 2020 Census data products, please see the [Demographic Data Index](https://gis.utah.gov/products/sgid/demographic/) available from the SGID.
+This dataset contains a polygon representing unpopulated areas in Utah, derived from 2010 Census and [UGRC addressing data](https://gis.utah.gov/products/sgid/location/address-points/). For 2020 Census data products, please see the [Demographic Data Index](https://gis.utah.gov/products/sgid/demographic/) available from the SGID.
 
 ## Description
 
@@ -22,15 +22,15 @@ This dataset is a representation of Utah areas that have little to no population
 
 ### What is the purpose of the dataset?
 
-This dataset was created to represent the portion of Utah with little to no permanent population.  Geography is a fundamental aspect of the Census, providing the framework for the once-a-decade count of population and housing. You can read more about some of the key geography changes in the Kem C. Gardner Policy Institute's 2020 Census Geography [Blog](https://gardner.utah.edu/blog/blog-whats-new-in-utahs-census-2020-geography/) and [fact sheet](https://d36oiwf74r1rap.cloudfront.net/wp-content/uploads/Geog-FS-Mar2021.pdf).
+This dataset has been made available to the public for general reference and cartographic purposes.
 
 ### What does the dataset represent?
 
-This dataset displays areas that contain little or no residential districts or developed areas as a single polygon feature. This dataset does not contain demographic data.
+The polygon feature in this dataset indicates areas that contain little or no residential districts or developed areas. This dataset does not contain demographic data or other attributes.
 
 ### How was the dataset created?
 
-UGRC created this dataset using parts of the original 2010 Census data from the US Census Bureau. Populated census blocks and a buffer around known addresses were used erase populated areas within the state, thus leaving behind the unpopulated areas in this dataset.
+UGRC created this dataset using parts of the original 2010 Census data from the US Census Bureau. We used populated Census blocks and a buffer around known addresses to erase populated areas within the state, thus leaving behind the unpopulated areas in this dataset.
 
 ### How reliable and accurate is the dataset?
 


### PR DESCRIPTION
Current draft for [Utah Unpopulated Areas 2010 Approx](https://opendata.gis.utah.gov/datasets/utah::utah-unpopulated-areas-2010-approx/about), which unfortunately did not have any metadata to begin with. The metadata currently on the Open Data site and on AGOL is actually the metadata for the Utah State Boundary dataset. Thus, I made some assumptions about this dataset, such as figuring it is basically the same as the Populated areas just the inverse. If there are further details that ought to be included with this dataset, let me know! Thank you!