### PR TITLE
Judicial Districts

### DIFF
--- a/metadata/political/judicial_districts.md
+++ b/metadata/political/judicial_districts.md
@@ -1,0 +1,71 @@
+# Title
+
+Utah Judicial Districts
+
+## ID
+
+2dbeaa56-5046-4eca-8da1-e641792f17cb
+
+## Brief Summary
+
+Polygon boundaries of Utah State judicial court boundaries for cartography and general analysis.
+
+## Summary
+
+This dataset contains polygons representing areas of responsibility for judicial courts in Utah. This dataset contains boundary data only and does not contain further details on court cases, court addresses, or other information.
+
+## Description
+
+### What is the dataset?
+
+The Utah State Court System includes appellate courts such as the Utah Supreme Court, trial courts such as the District and Juvenile Courts, and other administrative bodies such as the Administrative Office of the Court. This dataset contains polygon boundaries for trial court jurisdictions in Utah, which are organized into eight judicial districts throughout the State. These judicial districts include many city and county courts and handle a wide variety of cases. You can learn more about judicial districts and their responsibilities on the [Utah State Courts website](https://www.utcourts.gov/en/about.html).
+
+### What is the purpose of the dataset?
+
+In addition to helping Utah residents know [which State Court District](https://www.utcourts.gov/en/about/miscellaneous/directory/map-of-judicial-districts.html) they are in, this dataset has been made available to the public for general cartographic and analytic purposes.
+
+### What does the dataset represent?
+
+Each polygon in this dataset represents the geographic jurisdiction of a judicial district in Utah. Features in this dataset include the districts, juvenile courts, and counties found within each polygon boundary.
+
+### How was the dataset created?
+
+UGRC developed this dataset using information submitted by the Utah Courts Administrative Office. We derived the boundary data from the [Utah County Boundaries](https://gis.utah.gov/products/sgid/boundaries/county/) dataset available on the SGID. We update this dataset as new information becomes available.
+
+### How reliable and accurate is the dataset?
+
+This dataset represents the most complete and current version of state judicial districts. Please reach out to [our team](https://gis.utah.gov/contact/) with any questions or concerns about this dataset.
+
+## Credits
+
+### Data Source
+
+- Utah Courts Administrative Office
+- UGRC
+
+### Host
+
+UGRC
+
+## Restrictions
+
+## License
+
+## Tags
+
+- Judicial system
+- Utah State Court System
+
+## Secondary Category
+
+## Data Page Link
+
+[https://gis.utah.gov/products/sgid/political/judicial-districts/]
+
+## Update
+
+### Update Schedule
+
+This dataset is updated as needed.
+
+### Previous Updates

--- a/metadata/political/judicial_districts.md
+++ b/metadata/political/judicial_districts.md
@@ -26,7 +26,7 @@ In addition to helping Utah residents know [which State Court District](https://
 
 ### What does the dataset represent?
 
-Each polygon in this dataset represents the geographic jurisdiction of a judicial district in Utah. Features in this dataset include the districts, juvenile courts, and counties found within each polygon boundary.
+Each polygon in this dataset represents the geographic jurisdiction of a judicial district in Utah. Features in this dataset include the district courts, juvenile courts, and counties found within each polygon boundary.
 
 ### How was the dataset created?
 


### PR DESCRIPTION
[This one](https://opendata.gis.utah.gov/datasets/utah::utah-judicial-districts/about) is very similar to [Utah State Courts](https://opendata.gis.utah.gov/datasets/utah::utah-state-court-districts/about). The polygon geometries are identical, they differ only in schema. As far as I know Utah State Courts is used by the Dept. of Public Safety and this dataset is not, and that seems to be the primary difference between them. Let me know if there are further differences to highlight. Thank you!