### PR TITLE
Ski Trails XC

### DIFF
--- a/metadata/recreation/ski_trails_xc.md
+++ b/metadata/recreation/ski_trails_xc.md
@@ -8,37 +8,55 @@ bb34ab61-671f-4923-a42b-b78c411bec0b
 
 ## Brief Summary
 
+Polyline dataset of groomed cross country trails at Soldier Hollow and Mountain Dell ski resorts.
+
 ## Summary
+
+This dataset contains polylines representing groomed cross country ski trails at the Soldier Hollow and Mountain Dell ski resorts. This dataset serves as a cartographic reference only and does not contain information on the pricing or availability of ski areas.
 
 ## Description
 
-Established cross country ski trails within in the State of Utah.
-
-This dataset will depict the groomed cross country ski trails available at commercial and public venues in Utah. It currently is incomplete and includes trails from Mountain Dell golf course and Soldier Hollow. Trails will be added by AGRC as received, or as staff time allows.
-
-This map layer will depict the groomed cross country ski trails available at commercial and public venues in Utah. The map layer is currently incomplete and includes trails from Mountain Dell golf course and Soldier Hollow, digitized from aerial photography in 2007. Trail features carry the trail name, the XC ski area they are within, and the length in meters. Trails are missing from: Brian Head, Eden Valley North Fork, Jeremy Ranch Park City Basin Rec/Round Valley, Park City White Pine, Snowbasin, and Sundance. Trails will be added by AGRC as received, or as staff time allows.
-
 ### What is the dataset?
+
+Cross country ski trails include groomed paths where visitors may ski, snowshoe, or engage in other winter sports activities.
 
 ### What is the purpose of the dataset?
 
+This layer has been made available to the public for general reference and cartographic purposes.
+
 ### What does the dataset represent?
+
+Each polyline in this dataset indicates the approximate path and length of a cross country ski trail. Features in this dataset include the trail name and ski area it is found in.
 
 ### How was the dataset created?
 
+UGRC digitized the trails in this dataset using aerial imagery from 2007.
+
+<!--- Are we planning on updating this dataset any time soon? --->
+
 ### How reliable and accurate is the dataset?
+
+This dataset is not comprehensive and does not contain all ski trails in Utah. Further ski trails at other resorts may be added to this dataset in the future. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
 
 ## Credits
 
 ### Data Source
 
+UGRC
+
 ### Host
+
+UGRC
 
 ## Restrictions
 
 ## License
 
 ## Tags
+
+- Winter sports
+- Tourism
+- Winter recreation
 
 ## Secondary Category
 
@@ -47,5 +65,7 @@ This map layer will depict the groomed cross country ski trails available at com
 ## Update
 
 ### Update Schedule
+
+This dataset is updated as needed.
 
 ### Previous Updates

--- a/metadata/recreation/ski_trails_xc.md
+++ b/metadata/recreation/ski_trails_xc.md
@@ -1,0 +1,51 @@
+# Title
+
+Utah Ski Trails XC
+
+## ID
+
+bb34ab61-671f-4923-a42b-b78c411bec0b
+
+## Brief Summary
+
+## Summary
+
+## Description
+
+Established cross country ski trails within in the State of Utah.
+
+This dataset will depict the groomed cross country ski trails available at commercial and public venues in Utah. It currently is incomplete and includes trails from Mountain Dell golf course and Soldier Hollow. Trails will be added by AGRC as received, or as staff time allows.
+
+This map layer will depict the groomed cross country ski trails available at commercial and public venues in Utah. The map layer is currently incomplete and includes trails from Mountain Dell golf course and Soldier Hollow, digitized from aerial photography in 2007. Trail features carry the trail name, the XC ski area they are within, and the length in meters. Trails are missing from: Brian Head, Eden Valley North Fork, Jeremy Ranch Park City Basin Rec/Round Valley, Park City White Pine, Snowbasin, and Sundance. Trails will be added by AGRC as received, or as staff time allows.
+
+### What is the dataset?
+
+### What is the purpose of the dataset?
+
+### What does the dataset represent?
+
+### How was the dataset created?
+
+### How reliable and accurate is the dataset?
+
+## Credits
+
+### Data Source
+
+### Host
+
+## Restrictions
+
+## License
+
+## Tags
+
+## Secondary Category
+
+## Data Page Link
+
+## Update
+
+### Update Schedule
+
+### Previous Updates

--- a/metadata/recreation/ski_trails_xc.md
+++ b/metadata/recreation/ski_trails_xc.md
@@ -32,8 +32,6 @@ Each polyline in this dataset indicates the approximate path and length of a cro
 
 UGRC digitized the trails in this dataset using aerial imagery from 2007.
 
-<!--- Are we planning on updating this dataset any time soon? --->
-
 ### How reliable and accurate is the dataset?
 
 This dataset is not comprehensive and does not contain all ski trails in Utah. Further ski trails at other resorts may be added to this dataset in the future. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.


### PR DESCRIPTION
[This layer ](https://opendata.gis.utah.gov/datasets/utah::utah-ski-trails-xc/about)only has ski trails for two ski resorts, Soldier Hollow and Mountain Dell. The original metadata describes this layer as "incomplete" and that we would be adding new trails as staff time allowed. It also said that the layer was digitized from aerial imagery from 2007, which leads me to believe there is not a solid update schedule for this layer. Are we planning on adding more trails to this layer or updating it to be more current?