### PR TITLE
Public Land Initiative HR5780 Areas & Lines

### DIFF
--- a/metadata/planning/public_lands_initiative_hr5780_areas_blm_2016.md
+++ b/metadata/planning/public_lands_initiative_hr5780_areas_blm_2016.md
@@ -30,7 +30,7 @@ Each polygon in this dataset indicates the geographic extent of an area included
 
 ### How was the dataset created?
 
-<!--- Did we create this one? --->
+This layer was created using data from government sources.
 
 ### How reliable and accurate is the dataset?
 

--- a/metadata/planning/public_lands_initiative_hr5780_areas_blm_2016.md
+++ b/metadata/planning/public_lands_initiative_hr5780_areas_blm_2016.md
@@ -8,29 +8,43 @@ Utah Public Lands Initiative HR 5780 Areas BLM 2016
 
 ## Brief Summary
 
+Polygon dataset of areas proposed for economic development or conservation as part of HR5780.
+
 ## Summary
+
+This dataset contains polygons representing areas included in HR5780 in January 2016. Features in this dataset include boundary information and a brief overview of the proposed designation for that area.
 
 ## Description
 
-Proposed areas referenced in the January 2016 Public Lands Initiative proposal for Utah.
-
-The Public Lands Initiative (PLI) is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah. The initiative is rooted in the belief that conservation and economic development can coexist and make Utah a better place to live, work, and visit. The PLI discussion draft is the result of: 13 different drafts by Reps. Rob Bishop and Jason Chaffetz The participation of over 120 different stakeholder organizations More than 65 proposals from groups outlining their vision for public land management in Eastern Utah More than 4 dozen on-the-ground field trips carried out by the delegation Numerous public meetings in rural Utah discussing the initiative Visit [www.UtahPLI.com] for detailed information.
-
 ### What is the dataset?
+
+The [Public Lands Initiative](https://www.congress.gov/bill/114th-congress/house-bill/5780), also known as HR5780, was a bill created to address a number of public land disputes in Utah. It was originally proposed in 2016 and sponsored by Representative Rob Bishop. This dataset contains polygons representing areas that were included in the original bill under a variety of designations, including wilderness, special management areas, and energy development.
 
 ### What is the purpose of the dataset?
 
+This dataset has been made available to the public for general reference and analytic purposes.
+
 ### What does the dataset represent?
+
+Each polygon in this dataset indicates the geographic extent of an area included in the Public Lands Initiative. Features in this dataset include the proposed name, data source, proposed designation for the area, county, acreage, and whether the area is being considered for economic development (class = opportunity) or resource conservation (class = conservation).
 
 ### How was the dataset created?
 
+<!--- Did we create this one? --->
+
 ### How reliable and accurate is the dataset?
+
+This dataset represents areas referenced in proposed legislation only and does not reflect current land designations, ownership, or management. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
 
 ## Credits
 
 ### Data Source
 
+BLM
+
 ### Host
+
+UGRC
 
 ## Restrictions
 
@@ -40,10 +54,17 @@ The Public Lands Initiative (PLI) is a locally-driven effort to bring resolution
 
 ## Secondary Category
 
+- Public lands
+- Federal land
+- State land
+- Conservation
+
 ## Data Page Link
 
 ## Update
 
 ### Update Schedule
+
+Static
 
 ### Previous Updates

--- a/metadata/planning/public_lands_initiative_hr5780_areas_blm_2016.md
+++ b/metadata/planning/public_lands_initiative_hr5780_areas_blm_2016.md
@@ -1,0 +1,49 @@
+# Title
+
+Utah Public Lands Initiative HR 5780 Areas BLM 2016
+
+## ID
+
+84b8b0f9-1c9e-4e65-b622-6c9c75fd82ff
+
+## Brief Summary
+
+## Summary
+
+## Description
+
+Proposed areas referenced in the January 2016 Public Lands Initiative proposal for Utah.
+
+The Public Lands Initiative (PLI) is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah. The initiative is rooted in the belief that conservation and economic development can coexist and make Utah a better place to live, work, and visit. The PLI discussion draft is the result of: 13 different drafts by Reps. Rob Bishop and Jason Chaffetz The participation of over 120 different stakeholder organizations More than 65 proposals from groups outlining their vision for public land management in Eastern Utah More than 4 dozen on-the-ground field trips carried out by the delegation Numerous public meetings in rural Utah discussing the initiative Visit [www.UtahPLI.com] for detailed information.
+
+### What is the dataset?
+
+### What is the purpose of the dataset?
+
+### What does the dataset represent?
+
+### How was the dataset created?
+
+### How reliable and accurate is the dataset?
+
+## Credits
+
+### Data Source
+
+### Host
+
+## Restrictions
+
+## License
+
+## Tags
+
+## Secondary Category
+
+## Data Page Link
+
+## Update
+
+### Update Schedule
+
+### Previous Updates

--- a/metadata/planning/public_lands_initiative_hr5780_lines_blm_2016.md
+++ b/metadata/planning/public_lands_initiative_hr5780_lines_blm_2016.md
@@ -1,0 +1,49 @@
+# Title
+
+Utah Public Lands Initiative HR 5780 Lines BLM 2016
+
+## ID
+
+7f4ace63-ef78-46a6-80be-ae8bd423e7c9
+
+## Brief Summary
+
+## Summary
+
+## Description
+
+Proposed areas referenced in the January 2016 Public Lands Initiative proposal for Utah.
+
+The Public Lands Initiative (PLI) is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah. The initiative is rooted in the belief that conservation and economic development can coexist and make Utah a better place to live, work, and visit. The PLI discussion draft is the result of: 13 different drafts by Reps. Rob Bishop and Jason Chaffetz The participation of over 120 different stakeholder organizations More than 65 proposals from groups outlining their vision for public land management in Eastern Utah More than 4 dozen on-the-ground field trips carried out by the delegation Numerous public meetings in rural Utah discussing the initiative Visit [www.UtahPLI.com] for detailed information.
+
+### What is the dataset?
+
+### What is the purpose of the dataset?
+
+### What does the dataset represent?
+
+### How was the dataset created?
+
+### How reliable and accurate is the dataset?
+
+## Credits
+
+### Data Source
+
+### Host
+
+## Restrictions
+
+## License
+
+## Tags
+
+## Secondary Category
+
+## Data Page Link
+
+## Update
+
+### Update Schedule
+
+### Previous Updates

--- a/metadata/planning/public_lands_initiative_hr5780_lines_blm_2016.md
+++ b/metadata/planning/public_lands_initiative_hr5780_lines_blm_2016.md
@@ -30,7 +30,7 @@ Each polyline in this dataset indicates the approximate path of a road or trail 
 
 ### How was the dataset created?
 
-<!--- Did we create this one? --->
+This layer was created using data from government sources.
 
 ### How reliable and accurate is the dataset?
 

--- a/metadata/planning/public_lands_initiative_hr5780_lines_blm_2016.md
+++ b/metadata/planning/public_lands_initiative_hr5780_lines_blm_2016.md
@@ -8,35 +8,57 @@ Utah Public Lands Initiative HR 5780 Lines BLM 2016
 
 ## Brief Summary
 
+Polyline dataset of roads or trails proposed for economic development or conservation as part of HR5780.
+
 ## Summary
+
+This dataset contains polylines representing roads, trails, or pathways included in HR5780 in January 2016. Features in this dataset include a brief overview of the proposed designation for that road or trail.
 
 ## Description
 
-Proposed areas referenced in the January 2016 Public Lands Initiative proposal for Utah.
-
-The Public Lands Initiative (PLI) is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah. The initiative is rooted in the belief that conservation and economic development can coexist and make Utah a better place to live, work, and visit. The PLI discussion draft is the result of: 13 different drafts by Reps. Rob Bishop and Jason Chaffetz The participation of over 120 different stakeholder organizations More than 65 proposals from groups outlining their vision for public land management in Eastern Utah More than 4 dozen on-the-ground field trips carried out by the delegation Numerous public meetings in rural Utah discussing the initiative Visit [www.UtahPLI.com] for detailed information.
-
 ### What is the dataset?
+
+The [Public Lands Initiative](https://www.congress.gov/bill/114th-congress/house-bill/5780), also known as HR5780, was a bill created to address a number of public land disputes in Utah. It was originally proposed in 2016 and sponsored by Representative Rob Bishop. This dataset contains polylines representing roads, trails, or other pathways that were included in the original bill.
 
 ### What is the purpose of the dataset?
 
+This dataset has been made available to the public for general reference and analytic purposes.
+
 ### What does the dataset represent?
+
+Each polyline in this dataset indicates the approximate path of a road or trail outlined in the Public Lands Initiative. Features in this dataset include the proposed name, data source, proposed designation for the feature, county, length in miles, and whether the area is being considered for economic development (class = opportunity) or resource conservation (class = conservation).
 
 ### How was the dataset created?
 
+<!--- Did we create this one? --->
+
 ### How reliable and accurate is the dataset?
+
+This dataset represents roads, trails, or paths referenced in proposed legislation only and does not reflect current land designations, ownership, or management. Please reach out to [our team](https://gis.utah.gov/contact/) with questions or concerns about this dataset.
 
 ## Credits
 
 ### Data Source
 
+BLM
+
 ### Host
+
+UGRC
 
 ## Restrictions
 
 ## License
 
 ## Tags
+
+- Public lands
+- Federal land
+- State land
+- Conservation
+- Roads
+- Trails
+- Pathways
 
 ## Secondary Category
 
@@ -45,5 +67,7 @@ The Public Lands Initiative (PLI) is a locally-driven effort to bring resolution
 ## Update
 
 ### Update Schedule
+
+Static
 
 ### Previous Updates


### PR DESCRIPTION
This pull request contains files for both the Public Land Initiative Area [polygons](https://opendata.gis.utah.gov/datasets/44943332b600478fa4a3bb5bbd400d57_0/explore?location=38.946471%2C-110.266919%2C-1.00) and the [polylines](https://opendata.gis.utah.gov/datasets/utah::utah-public-lands-initiative-hr5780-lines-blm-2016/about), both of which had identical metadata, so I had do a little guesswork with the lines dataset. Let me know if there are any corrections that need to be made. Thank you!